### PR TITLE
Gcp depoy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM golang:1.17
 
 WORKDIR /go/src/app
 
-ADD . /go/src/app
+ADD . .
 
 EXPOSE 8080

--- a/app/.gcloudignore
+++ b/app/.gcloudignore
@@ -1,0 +1,25 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with `go test -c`
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -1,0 +1,1 @@
+runtime: go115


### PR DESCRIPTION
I set Deploy to Google App Engine .

How to deploy

```
cd app
gcloud app deploy
```

URL

https://clever-bit-333501.an.r.appspot.com/

References
- https://dev.classmethod.jp/articles/gae-webapp/
- https://note.com/mkudo/n/n28ae7843add7
- https://cloud.google.com/appengine/docs/flexible/custom-runtimes/configuring-your-app-with-app-yaml?hl=ja

and 

Modify Dockerfile 

I modified Dockerfile refenced following doc
https://hub.docker.com/_/golang