### PR TITLE
Fix character-set

### DIFF
--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -1,8 +1,5 @@
 [mysqld]
-character-set-server=utf8
-
-[mysql]
-default-character-set=utf8
+character-set-server=utf8mb4
 
 [client]
-default-character-set=utf8
+default-character-set=utf8mb4


### PR DESCRIPTION
There was a warning, following

```
Warning --character-set-server: 'utf8' is currently an alias for the character set UTF8MB3,
but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
```

So I fixed character-set to utf8mb4 .
Referenced https://qiita.com/decoch/items/bfa125ae45c16811536a